### PR TITLE
Fix rewardedBreak callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,9 +132,3 @@ $ yarn watch
 Server running at http://localhost:1234
 ```
 And point your browser to http://localhost:1234
-
-
-## Asset Credits
-
-Background music credits:
-https://github.com/photonstorm/phaser-examples/blob/master/examples/assets/audio/bodenstaendig_2000_in_rock_4bit.mp3

--- a/example/scenes/loading.js
+++ b/example/scenes/loading.js
@@ -6,7 +6,6 @@ import PlayScene from './play'
 export default class LoadingScene extends Phaser.Scene {
   create () {
     this.load.image('logo', 'textures/logo.png')
-    this.load.audio('background', 'audio/bodenstaendig_2000_in_rock_4bit.mp3')
 
     this.load.once('complete', () => {
       console.log('Loading complete')

--- a/example/scenes/menu.js
+++ b/example/scenes/menu.js
@@ -2,12 +2,6 @@ import Phaser from 'phaser'
 
 export default class MenuScene extends Phaser.Scene {
   create () {
-    if (!this.sound.get('background')) {
-      this.sound.play('background', {
-        volume: 0.1
-      })
-    }
-
     this.playButton = this.add.text(640, 460, 'Start!', {
       font: '48px Impact',
       fill: 'black'

--- a/example/scenes/menu.js
+++ b/example/scenes/menu.js
@@ -37,6 +37,7 @@ export default class MenuScene extends Phaser.Scene {
         this.rewardButton.addListener('pointerdown', () => {
           // This function will mute and disable keyboard input for you
           poki.rewardedBreak().then((success) => {
+            console.log('should rewards?', success)
             if (success) {
               // Give coins!
             }

--- a/lib/poki.js
+++ b/lib/poki.js
@@ -33,7 +33,12 @@ export class PokiPlugin extends Phaser.Plugins.BasePlugin {
         this._initializeHooks = undefined
       }).catch(err => {
         console.error('PokiSDK failed', err)
+        this.initialized = true
         this.hasAdblock = true
+
+        this.game.events.emit(EVENT_INITIALIZED, this)
+        this._initializeHooks.forEach(f => f(this))
+        this._initializeHooks = undefined
       })
     })
     script.addEventListener('error', (e) => {
@@ -168,7 +173,7 @@ export class PokiPlugin extends Phaser.Plugins.BasePlugin {
         const wasMuted = this.game.sound.mute
         this.game.sound.mute = true
 
-        this.sdk[`${type}Break`]().then(() => {
+        this.sdk[`${type}Break`]().then((success) => {
           if (wasKeyboardEnbaled) {
             this.game.input.keyboard.enabled = true
           }
@@ -177,10 +182,10 @@ export class PokiPlugin extends Phaser.Plugins.BasePlugin {
             this.game.sound.mute = false
           }
 
-          resolve()
+          resolve(success)
         })
       })
     }
-    return Promise.resolve()
+    return Promise.resolve(false)
   }
 }


### PR DESCRIPTION
This PR will fix an issue where the success-boolean from a rewardedBreak (or a commericalBreak) wasn't passed along to the callback in the plugin.

Also changed the way this plugin handles a failure to load the PokiSDK, it now still runs the post-initialize hooks.


Note: removed the missing background music.