### PR TITLE
Removes --save-dev flags from install instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ always check the example in the [/example](example/) directory.
 First, you have to make sure to add the `@poki/phaser-3` plugin as a dependency 
 to your project:
 ```bash
-$ npm install --save-dev @poki/phaser-3
+$ npm install @poki/phaser-3
 # or
-$ yarn add --dev @poki/phaser-3
+$ yarn add @poki/phaser-3
 ```
 
 ### Install plugin to Phaser's configuration


### PR DESCRIPTION
These instructions would have installed the dependency as a developer dependency and would not be included with the production build `node_modules/` folder.