### PR TITLE
Updates import statements by removing default export Phaser.

### DIFF
--- a/lib/poki.js
+++ b/lib/poki.js
@@ -1,8 +1,8 @@
-import Phaser from 'phaser'
+import { Plugins } from 'phaser'
 
 export const EVENT_INITIALIZED = 'poki:initialized'
 
-export class PokiPlugin extends Phaser.Plugins.BasePlugin {
+export class PokiPlugin extends Plugins.BasePlugin {
   init ({ loadingSceneKey, gameplaySceneKey, autoCommercialBreak }) {
     this._loadingSceneKey = loadingSceneKey
     this._gameplaySceneKey = gameplaySceneKey


### PR DESCRIPTION
An update to Phaser 3 has removed the default export from it's module, so using `import Phaser from 'phaser';` will no longer work.

So this simply updates the import statement and it's usage.